### PR TITLE
OSC-1458 - Reduce api calls to FooDataSource

### DIFF
--- a/rdl/data_sources/MsSqlDataSource.py
+++ b/rdl/data_sources/MsSqlDataSource.py
@@ -12,6 +12,7 @@ from sqlalchemy.sql import text
 
 from rdl.ColumnTypeResolver import ColumnTypeResolver
 from rdl.data_sources.ChangeTrackingInfo import ChangeTrackingInfo
+from rdl.data_sources.SourceTableInfo import SourceTableInfo
 from rdl.shared import Providers
 from rdl.shared.Utils import prevent_senstive_data_logging
 
@@ -111,21 +112,11 @@ class MsSqlDataSource(object):
 
         return f"{select_sql} \n {from_sql} \n {where_sql} \n {order_by_sql};"
 
-    # Returns an array of configured_columns containing only columns that this data source supports. Logs invalid ones.
-    def assert_data_source_is_valid(self, table_config, configured_columns):
+    def get_table_info(self, table_config, last_known_sync_version):
         columns_in_database = self.__get_table_columns(table_config)
-
-        for column in configured_columns:
-            self.__assert_column_exists(column['source_name'],
-                                        columns_in_database,
-                                        f"{table_config['schema']}.{table_config['name']}")
-
-    def __assert_column_exists(self, column_name, columns_in_database, table_name):
-        if column_name in columns_in_database:
-            return True
-
-        message = f'Column {column_name} does not exist in source table {table_name}'
-        raise ValueError(message)
+        change_tracking_info = self.__get_change_tracking_info(table_config, last_known_sync_version)
+        source_table_info = SourceTableInfo.from_change_tracking_info(columns_in_database, change_tracking_info)
+        return source_table_info
 
     def __get_table_columns(self, table_config):
         metadata = MetaData()
@@ -149,7 +140,7 @@ class MsSqlDataSource(object):
 
         return data_frame
 
-    def get_change_tracking_info(self, table_config, last_known_sync_version):
+    def __get_change_tracking_info(self, table_config, last_known_sync_version):
 
         if last_known_sync_version is None:
             last_known_sync_version = 'NULL'

--- a/rdl/data_sources/MsSqlDataSource.py
+++ b/rdl/data_sources/MsSqlDataSource.py
@@ -115,7 +115,7 @@ class MsSqlDataSource(object):
     def get_table_info(self, table_config, last_known_sync_version):
         columns_in_database = self.__get_table_columns(table_config)
         change_tracking_info = self.__get_change_tracking_info(table_config, last_known_sync_version)
-        source_table_info = SourceTableInfo.from_change_tracking_info(columns_in_database, change_tracking_info)
+        source_table_info = SourceTableInfo(columns_in_database, change_tracking_info)
         return source_table_info
 
     def __get_table_columns(self, table_config):

--- a/rdl/data_sources/SourceTableInfo.py
+++ b/rdl/data_sources/SourceTableInfo.py
@@ -2,17 +2,6 @@ from rdl.data_sources.ChangeTrackingInfo import ChangeTrackingInfo
 
 
 class SourceTableInfo:
-    def __init__(self, column_names: [],
-                 last_sync_version: str, sync_version: str,
-                 force_full_load: str, data_changed_since_last_sync: str):
+    def __init__(self, column_names: [], change_tracking_info: ChangeTrackingInfo):
         self.column_names = column_names
-        self.last_sync_version = last_sync_version
-        self.sync_version = sync_version
-        self.force_full_load = force_full_load
-        self.data_changed_since_last_sync = data_changed_since_last_sync
-
-    @classmethod
-    def from_change_tracking_info(cls, column_names: [], change_tracking_info: ChangeTrackingInfo):
-        return cls(column_names,
-                   change_tracking_info.last_sync_version, change_tracking_info.sync_version,
-                   change_tracking_info.force_full_load, change_tracking_info.data_changed_since_last_sync)
+        self.change_tracking_info = change_tracking_info

--- a/rdl/data_sources/SourceTableInfo.py
+++ b/rdl/data_sources/SourceTableInfo.py
@@ -1,0 +1,18 @@
+from rdl.data_sources.ChangeTrackingInfo import ChangeTrackingInfo
+
+
+class SourceTableInfo:
+    def __init__(self, column_names: [],
+                 last_sync_version: str, sync_version: str,
+                 force_full_load: str, data_changed_since_last_sync: str):
+        self.column_names = column_names
+        self.last_sync_version = last_sync_version
+        self.sync_version = sync_version
+        self.force_full_load = force_full_load
+        self.data_changed_since_last_sync = data_changed_since_last_sync
+
+    @classmethod
+    def from_change_tracking_info(cls, column_names: [], change_tracking_info: ChangeTrackingInfo):
+        return cls(column_names,
+                   change_tracking_info.last_sync_version, change_tracking_info.sync_version,
+                   change_tracking_info.force_full_load, change_tracking_info.data_changed_since_last_sync)

--- a/tests/unit_tests/test_MsSqlDataSource.py
+++ b/tests/unit_tests/test_MsSqlDataSource.py
@@ -65,14 +65,12 @@ class TestMsSqlDataSource(unittest.TestCase):
         for table in TestMsSqlDataSource.table_configs:
             print("TESTING ON TABLE: " + table["source_table"]["name"])
             print("FIRST TEST: INITIALISE TABLE")
-            results = TestMsSqlDataSource.data_source.get_table_info(
-                table["source_table"], last_sync_version).change_tracking_info
+            results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
             self.assertEqual(results.force_full_load, True)
 
             print("SECOND TEST: NO CHANGES")
             last_sync_version = results.sync_version
-            results = TestMsSqlDataSource.data_source.get_table_info(
-                table["source_table"], last_sync_version).change_tracking_info
+            results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
             self.assertEqual(results.force_full_load, False)
 
             print("OPERATION TESTS")
@@ -82,22 +80,18 @@ class TestMsSqlDataSource(unittest.TestCase):
                 TestMsSqlDataSource.data_source.database_engine.execute(
                     text(operation_string).execution_options(autocommit=True))
 
-                results = TestMsSqlDataSource.data_source.get_table_info(
-                    table["source_table"], last_sync_version).change_tracking_info
+                results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
                 self.assertEqual(results.force_full_load, False, msg="Failed on: " + operation_string)
                 last_sync_version = results.sync_version
 
             print("EXTRA TEST: NO CHANGES")
             last_sync_version = results.sync_version
-            results = TestMsSqlDataSource.data_source.get_table_info(
-                table["source_table"], last_sync_version).change_tracking_info
+            results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
             self.assertEqual(results.force_full_load, False)
 
             print("EXTRA TEST: LOST TRACK")
             last_sync_version = -1
-            results = TestMsSqlDataSource.data_source\
-                .get_table_info(table["source_table"], last_sync_version)\
-                .change_tracking_info
+            results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
             self.assertEqual(results.force_full_load, True)
 
     def test_can_handle_connection_string(self):

--- a/tests/unit_tests/test_MsSqlDataSource.py
+++ b/tests/unit_tests/test_MsSqlDataSource.py
@@ -59,20 +59,20 @@ class TestMsSqlDataSource(unittest.TestCase):
         TestMsSqlDataSource.data_source.database_engine.execute(text(TEAR_DOWN_STRING))
         TestMsSqlDataSource.data_source = None
 
-    def test_get_change_tracking_info(self):
+    def test_get_table_info_change_tracking_info(self):
 
         last_sync_version = None
         for table in TestMsSqlDataSource.table_configs:
             print("TESTING ON TABLE: " + table["source_table"]["name"])
             print("FIRST TEST: INITIALISE TABLE")
-            results = TestMsSqlDataSource.data_source.get_change_tracking_info(
-                table["source_table"], last_sync_version)
+            results = TestMsSqlDataSource.data_source.get_table_info(
+                table["source_table"], last_sync_version).change_tracking_info
             self.assertEqual(results.force_full_load, True)
 
             print("SECOND TEST: NO CHANGES")
             last_sync_version = results.sync_version
-            results = TestMsSqlDataSource.data_source.get_change_tracking_info(
-                table["source_table"], last_sync_version)
+            results = TestMsSqlDataSource.data_source.get_table_info(
+                table["source_table"], last_sync_version).change_tracking_info
             self.assertEqual(results.force_full_load, False)
 
             print("OPERATION TESTS")
@@ -82,20 +82,22 @@ class TestMsSqlDataSource(unittest.TestCase):
                 TestMsSqlDataSource.data_source.database_engine.execute(
                     text(operation_string).execution_options(autocommit=True))
 
-                results = TestMsSqlDataSource.data_source.get_change_tracking_info(
-                    table["source_table"], last_sync_version)
+                results = TestMsSqlDataSource.data_source.get_table_info(
+                    table["source_table"], last_sync_version).change_tracking_info
                 self.assertEqual(results.force_full_load, False, msg="Failed on: " + operation_string)
                 last_sync_version = results.sync_version
 
             print("EXTRA TEST: NO CHANGES")
             last_sync_version = results.sync_version
-            results = TestMsSqlDataSource.data_source.get_change_tracking_info(
-                table["source_table"], last_sync_version)
+            results = TestMsSqlDataSource.data_source.get_table_info(
+                table["source_table"], last_sync_version).change_tracking_info
             self.assertEqual(results.force_full_load, False)
 
             print("EXTRA TEST: LOST TRACK")
             last_sync_version = -1
-            results = TestMsSqlDataSource.data_source.get_change_tracking_info(table["source_table"], last_sync_version)
+            results = TestMsSqlDataSource.data_source\
+                .get_table_info(table["source_table"], last_sync_version)\
+                .change_tracking_info
             self.assertEqual(results.force_full_load, True)
 
     def test_can_handle_connection_string(self):

--- a/tests/unit_tests/test_MsSqlDataSource.py
+++ b/tests/unit_tests/test_MsSqlDataSource.py
@@ -65,12 +65,14 @@ class TestMsSqlDataSource(unittest.TestCase):
         for table in TestMsSqlDataSource.table_configs:
             print("TESTING ON TABLE: " + table["source_table"]["name"])
             print("FIRST TEST: INITIALISE TABLE")
-            results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
+            results = TestMsSqlDataSource.data_source.get_table_info(
+                table["source_table"], last_sync_version).change_tracking_info
             self.assertEqual(results.force_full_load, True)
 
             print("SECOND TEST: NO CHANGES")
             last_sync_version = results.sync_version
-            results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
+            results = TestMsSqlDataSource.data_source.get_table_info(
+                table["source_table"], last_sync_version).change_tracking_info
             self.assertEqual(results.force_full_load, False)
 
             print("OPERATION TESTS")
@@ -80,18 +82,22 @@ class TestMsSqlDataSource(unittest.TestCase):
                 TestMsSqlDataSource.data_source.database_engine.execute(
                     text(operation_string).execution_options(autocommit=True))
 
-                results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
+                results = TestMsSqlDataSource.data_source.get_table_info(
+                    table["source_table"], last_sync_version).change_tracking_info
                 self.assertEqual(results.force_full_load, False, msg="Failed on: " + operation_string)
                 last_sync_version = results.sync_version
 
             print("EXTRA TEST: NO CHANGES")
             last_sync_version = results.sync_version
-            results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
+            results = TestMsSqlDataSource.data_source.get_table_info(
+                table["source_table"], last_sync_version).change_tracking_info
             self.assertEqual(results.force_full_load, False)
 
             print("EXTRA TEST: LOST TRACK")
             last_sync_version = -1
-            results = TestMsSqlDataSource.data_source.get_table_info(table["source_table"], last_sync_version)
+            results = TestMsSqlDataSource.data_source\
+                .get_table_info(table["source_table"], last_sync_version)\
+                .change_tracking_info
             self.assertEqual(results.force_full_load, True)
 
     def test_can_handle_connection_string(self):


### PR DESCRIPTION
Reduce api calls to FooDataSource to only two:
- one to fetch meta-data
- and one to fetch data

CI build can be tracked [here](https://ci.appveyor.com/project/PageUp/relational-data-loader-fkwak/builds/25892986). It's passed. ✔️ 