### PR TITLE
add retry policy when invoking lambda

### DIFF
--- a/rdl/shared/Constants.py
+++ b/rdl/shared/Constants.py
@@ -1,5 +1,6 @@
 APP_NAME = "Relational Data Loader"
 DATA_PIPELINE_EXECUTION_SCHEMA_NAME = "rdl"
+MAX_AWS_LAMBDA_INVOKATION_ATTEMPTS = 3
 
 
 class FullRefreshReason:


### PR DESCRIPTION
Note: this will apply to all errors from when lambda is invoked.. 
- best case scenario, it'd retry in case of connection / availability issues
- worst case scenario, it'd delay a real data-related error by repeating attempts which are going to fail with the same result anyway.