### PR TITLE
[SP-333] Assume Role Support

### DIFF
--- a/rdl/data_sources/AWSLambdaDataSource.py
+++ b/rdl/data_sources/AWSLambdaDataSource.py
@@ -3,6 +3,7 @@ import pandas
 import json
 import boto3
 import time
+import datetime
 
 from rdl.data_sources.ChangeTrackingInfo import ChangeTrackingInfo
 from rdl.data_sources.SourceTableInfo import SourceTableInfo
@@ -11,15 +12,21 @@ from rdl.shared.Utils import prevent_senstive_data_logging
 
 
 class AWSLambdaDataSource(object):
-    # 'aws-lambda://tenant=543_dc2;function=123456789012:function:my-function;'
+    # 'aws-lambda://tenant=543_dc2;function=123456789012:function:my-function;role=arn:aws:iam::123456789012:role/RoleName;'
     CONNECTION_STRING_PREFIX = "aws-lambda://"
     CONNECTION_STRING_GROUP_SEPARATOR = ";"
     CONNECTION_STRING_KEY_VALUE_SEPARATOR = "="
+    CONNECTION_STRING_ROLE_KEY = "role"
+
+    AWS_SERVICE_LAMBDA = "lambda"
+    AWS_SERVICE_S3 = "s3"
 
     def __init__(self, connection_string, logger=None):
         self.logger = logger or logging.getLogger(__name__)
+
         if not AWSLambdaDataSource.can_handle_connection_string(connection_string):
             raise ValueError(connection_string)
+
         self.connection_string = connection_string
         self.connection_data = dict(
             kv.split(AWSLambdaDataSource.CONNECTION_STRING_KEY_VALUE_SEPARATOR)
@@ -29,8 +36,19 @@ class AWSLambdaDataSource(object):
             .rstrip(AWSLambdaDataSource.CONNECTION_STRING_GROUP_SEPARATOR)
             .split(AWSLambdaDataSource.CONNECTION_STRING_GROUP_SEPARATOR)
         )
-        self.aws_lambda_client = boto3.client("lambda")
-        self.aws_s3_client = boto3.client("s3")
+
+        self.aws_sts_client = boto3.client("sts")
+        role_credentials = self.__assume_role(
+            self.connection_data[self.CONNECTION_STRING_ROLE_KEY],
+            f'dwp_{self.connection_data["tenant"]}',
+        )
+
+        self.aws_lambda_client = self.__get_aws_client(
+            self.AWS_SERVICE_LAMBDA, role_credentials
+        )
+        self.aws_s3_client = self.__get_aws_client(
+            self.AWS_SERVICE_S3, role_credentials
+        )
 
     @staticmethod
     def can_handle_connection_string(connection_string):
@@ -125,7 +143,7 @@ class AWSLambdaDataSource(object):
                     {
                         "Name": col["source_name"],
                         "DataType": col["destination"]["type"],
-                        "IsPrimaryKey": col["destination"]["primary_key"]
+                        "IsPrimaryKey": col["destination"]["primary_key"],
                     }
                     for col in columns_config
                 ],
@@ -148,17 +166,64 @@ class AWSLambdaDataSource(object):
     def __get_data_frame(self, data: [[]], column_names: []):
         return pandas.DataFrame(data=data, columns=column_names)
 
+    def __assume_role(self, role_arn, session_name):
+        self.logger.debug(f"\nAssuming role with ARN: {role_arn}")
+
+        assume_role_response = self.aws_sts_client.assume_role(
+            RoleArn=role_arn, RoleSessionName=session_name
+        )
+
+        role_credentials = assume_role_response["Credentials"]
+
+        self.role_session_expiry = role_credentials["Expiration"]
+
+        return role_credentials
+
+    def __get_aws_client(self, service, credentials):
+        return boto3.client(
+            service_name=service,
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+        )
+
+    def __refresh_aws_clients_if_expired(self):
+        current_datetime = datetime.datetime.now()
+
+        if (
+            current_datetime > self.role_session_expiry - datetime.timedelta(minutes=5)
+            and current_datetime < self.role_session_expiry
+        ):
+            role_credentials = self.__assume_role(
+                self.connection_data[self.CONNECTION_STRING_ROLE_KEY],
+                f'dwp_{self.connection_data["tenant"]}',
+            )
+
+            self.aws_lambda_client = self.__get_aws_client(
+                self.AWS_SERVICE_LAMBDA, role_credentials
+            )
+            self.aws_s3_client = self.__get_aws_client(
+                self.AWS_SERVICE_S3, role_credentials
+            )
+
     def __invoke_lambda(self, pay_load):
         max_attempts = Constants.MAX_AWS_LAMBDA_INVOKATION_ATTEMPTS
         retry_delay = Constants.AWS_LAMBDA_RETRY_DELAY_SECONDS
         response_payload = None
 
-        for current_attempt in list(range(1, max_attempts+1, 1)):
+        for current_attempt in list(range(1, max_attempts + 1, 1)):
+
+            self.__refresh_aws_clients_if_expired()
+
             if current_attempt > 1:
-                self.logger.debug(f"\nDelaying retry for {(current_attempt - 1) ^ retry_delay} seconds")
+                self.logger.debug(
+                    f"\nDelaying retry for {(current_attempt - 1) ^ retry_delay} seconds"
+                )
                 time.sleep((current_attempt - 1) ^ retry_delay)
 
-            self.logger.debug(f"\nRequest being sent to Lambda, attempt {current_attempt} of {max_attempts}:")
+            self.logger.debug(
+                f"\nRequest being sent to Lambda, attempt {current_attempt} of {max_attempts}:"
+            )
             self.logger.debug(pay_load)
 
             lambda_response = self.aws_lambda_client.invoke(
@@ -170,7 +235,9 @@ class AWSLambdaDataSource(object):
 
             response_status_code = int(lambda_response["StatusCode"])
             response_function_error = lambda_response.get("FunctionError")
-            self.logger.debug(f"\nResponse received from Lambda, attempt {current_attempt} of {max_attempts}:")
+            self.logger.debug(
+                f"\nResponse received from Lambda, attempt {current_attempt} of {max_attempts}:"
+            )
             self.logger.debug(f'Response - StatusCode = "{response_status_code}"')
             self.logger.debug(f'Response - FunctionError = "{response_function_error}"')
 
@@ -179,10 +246,12 @@ class AWSLambdaDataSource(object):
             if response_status_code != 200 or response_function_error:
                 self.logger.error(
                     f'Error in response from aws lambda \'{self.connection_data["function"]}\', '
-                    f'attempt {current_attempt} of {max_attempts}'
+                    f"attempt {current_attempt} of {max_attempts}"
                 )
                 self.logger.error(f"Response - Status Code = {response_status_code}")
-                self.logger.error(f"Response - Error Function = {response_function_error}")
+                self.logger.error(
+                    f"Response - Error Function = {response_function_error}"
+                )
                 self.logger.error(f"Response - Error Details:")
                 # the below is risky as it may contain actual data if this line is reached in case of success
                 # however, the same Payload field is used to return actual error details in case of failure

--- a/rdl/data_sources/AWSLambdaDataSource.py
+++ b/rdl/data_sources/AWSLambdaDataSource.py
@@ -191,7 +191,8 @@ class AWSLambdaDataSource(object):
         )
 
     def __refresh_aws_clients_if_expired(self):
-        current_datetime = datetime.datetime.now()
+        # this is due to AWS returning their expiry date in UTC
+        current_datetime = datetime.datetime.now(datetime.timezone.utc)
 
         if (
             current_datetime > self.role_session_expiry - datetime.timedelta(minutes=5)


### PR DESCRIPTION
# SP-333
### Changes
- Add `CONNECTION_DATA_ROLE_KEY` constant
- Add `CONNECTION_DATA_FUNCTION_KEY` constant
- Add `CONNECTION_DATA_TENANT_KEY` constant
- Add `AWS_SERVICE_LAMBDA` constant
- Add `AWS_SERVICE_S3` constant
- Add `sts` client to `AWSLambdaDataSource`
- Add `__assume_role(...)` method
    - Returns credentials from response
- Add `__get_aws_client(...)` method
- Add `__refresh_aws_clients_if_expired(...)` method
- Reformat code

### Notes
#### Assume Role
The following clients will now be instantiated with AWS credentials:
- Lambda
- S3

If the clients are nearing their expiration date (~5 minutes), we will re-assume the role for a fresh set of credentials and update the clients accordingly. 

#### AWS Lambda Connection String
Now expects `role=arn:aws:iam:{accountId}:role/{roleName}`