### PR TITLE
Preserve after deletion

### DIFF
--- a/rdl/DestinationTableManager.py
+++ b/rdl/DestinationTableManager.py
@@ -150,11 +150,15 @@ class DestinationTableManager(object):
 
         deleted_column = f"EXCLUDED.{Providers.AuditColumnsNames.IS_DELETED}"
         for column_config in columns_config:
-            if "preserve_after_delete" in column_config["destination"] and column_config["destination"]["preserve_after_delete"]:
-                existing_column = f"{target_table_name}.{column_config["destination"]["name"]}"
-                excluded_column = f"EXCLUDED.{column_config["destination"]["name"]}"
+            if (
+                "preserve_after_delete" in column_config["destination"]
+                and column_config["destination"]["preserve_after_delete"]
+            ):
+                col_name = column_config["destination"]["name"]
+                existing_column = f"{target_table_name}.{col_name}"
+                excluded_column = f"EXCLUDED.{col_name}"
                 sql_builder.write(
-                    f"{column_config["destination"]["name"]} = CASE WHEN {deleted_column} = TRUE THEN {existing_column} ELSE {excluded_column} END, \n"
+                    f"{col_name} = CASE WHEN {deleted_column} = TRUE THEN {existing_column} ELSE {excluded_column} END, \n"
                 )
             else:
                 sql_builder.write(


### PR DESCRIPTION
Add support for the `preserve_after_delete` flag. Adding this flag means that when a row is physically deleted in the source database, the logical deletion in the destination db preserves the value of that column. Default behaviour is for the value to have a null/default value.

Example:
```json
    {
      "destination": {
        "name": "id",
        "nullable": true,
        "primary_key": false,
        "type": "int",
        "preserve_after_delete": true
      },
      "source_name": "lTableId"
    }
```